### PR TITLE
Added caching of the currency conversion XML

### DIFF
--- a/harbour-unitconverter.pro
+++ b/harbour-unitconverter.pro
@@ -9,11 +9,13 @@
 TARGET = harbour-unitconverter
 
 CONFIG += sailfishapp c++11
+QT += network
 
 SOURCES += src/harbour-unitconverter.cpp \
     src/custommodel.cpp \
     src/converter.cpp \
-    src/logic.cpp
+    src/logic.cpp \
+    src/currencycache.cpp
 
 OTHER_FILES += qml/harbour-unitconverter.qml \
     qml/cover/CoverPage.qml \
@@ -41,7 +43,8 @@ OTHER_FILES += qml/harbour-unitconverter.qml \
 HEADERS += \
     src/custommodel.h \
     src/converter.h \
-    src/logic.h
+    src/logic.h \
+    src/currencycache.h
 
 RESOURCES += \
     MyResource.qrc

--- a/qml/pages/MainPage.qml
+++ b/qml/pages/MainPage.qml
@@ -70,7 +70,7 @@ Page {
 
         XmlListModel {
              id: xmlModel
-             source: url
+             xml: currencycache.xml
              namespaceDeclarations: "declare namespace gesmes='http://www.gesmes.org/xml/2002-08-01';"
                                     +"declare default element namespace 'http://www.ecb.int/vocabulary/2002-08-01/eurofxref';"
              query: "/gesmes:Envelope/Cube/Cube/Cube"

--- a/qml/pages/OptionsPage.qml
+++ b/qml/pages/OptionsPage.qml
@@ -15,7 +15,7 @@ Dialog {
         anchors.fill: parent
         clip: true
         focus: true
-        contentHeight: col.height + dialogHeader.height
+        contentHeight: col.height + dialogHeader.height + 2*Theme.paddingMedium
 
         DialogHeader {
             id: dialogHeader

--- a/qml/pages/OptionsPage.qml
+++ b/qml/pages/OptionsPage.qml
@@ -96,6 +96,7 @@ Dialog {
                     MenuItem { text: qsTr("Daily update"); font.family: "Verdana" }
                     MenuItem { text: qsTr("Weekly update"); font.family: "Verdana" }
                     MenuItem { text: qsTr("Monthly update"); font.family: "Verdana" }
+                    MenuItem { text: qsTr("Always at application start"); font.family: "Verdana" }
                     MenuItem { text: qsTr("Disable automatic update"); font.family: "Verdana" }
                 }
             }

--- a/qml/pages/OptionsPage.qml
+++ b/qml/pages/OptionsPage.qml
@@ -15,11 +15,15 @@ Dialog {
         anchors.fill: parent
         clip: true
         focus: true
+        contentHeight: col.height + dialogHeader.height
 
         DialogHeader {
             id: dialogHeader
             width: parent.width
         }
+
+        ScrollDecorator {}
+
         Column {
             id: col
             anchors {
@@ -71,16 +75,42 @@ Dialog {
                     }
                 }
             }
-
+            TextArea {
+                focus: true
+                font.family: "Verdana"
+                width: parent.width
+                color: Theme.primaryColor
+                font.pixelSize: Theme.fontSizeSmall
+                wrapMode: TextEdit.WordWrap
+                text: qsTr("You can change the rate at which the currency rates are updated." +
+                           "If you disable the automatic update, you have to start the update process manually.")
+                readOnly: true
+            }
+            ComboBox {
+                id: intervalselection
+                visible: true
+                label: qsTr("Select update interval")
+                width: parent.width
+                currentIndex: currencycache.interval()
+                menu: ContextMenu {
+                    MenuItem { text: qsTr("Daily update"); font.family: "Verdana" }
+                    MenuItem { text: qsTr("Weekly update"); font.family: "Verdana" }
+                    MenuItem { text: qsTr("Monthly update"); font.family: "Verdana" }
+                    MenuItem { text: qsTr("Disable automatic update"); font.family: "Verdana" }
+                }
+            }
+            Button {
+                text: qsTr("Update currency cache")
+                width: parent.width
+                onClicked: currencycache.updateNow()
+            }
         }
+    }
+    onAccepted: {
+        currencycache.setInterval(intervalselection.currentIndex)
     }
     onOpened: {
         hActivationSwitch.checked = HV.HORIZONTALLINESACTIVE;
         vActivationSwitch.checked = HV.VERTICALLINESACTIVE;
     }
-    /*
-    onAccepted: {
-    }
-    */
-
 }

--- a/src/currencycache.cpp
+++ b/src/currencycache.cpp
@@ -1,0 +1,104 @@
+#include "currencycache.h"
+
+#include <QDate>
+#include <QDebug>
+
+const QUrl CurrencyCache::URL("http://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml");
+
+CurrencyCache::CurrencyCache(QObject *parent) :
+    QObject(parent),
+    _xml(),
+    _interval(),
+    _settings(),
+    _manager()
+{
+    _xml = _settings.value("xml", "").toString();
+    _interval = static_cast<UpdateInterval>(_settings.value("interval", UpdateInterval::DAILY).toInt());
+
+    QObject::connect(&_manager, SIGNAL(finished(QNetworkReply*)), this, SLOT(getReply(QNetworkReply*)));
+
+    checkUpdate();
+}
+
+QString CurrencyCache::XML()
+{
+    return _xml;
+}
+
+void CurrencyCache::setXML(QString xml)
+{
+    _xml = xml;
+    _settings.setValue("xml", _xml);
+    emit xmlChanged(_xml);
+}
+
+void CurrencyCache::checkUpdate()
+{
+    if(_xml == "" && _interval != NEVER)
+    {
+        updateNow();
+        return;
+    }
+    qlonglong current_time = QDate::currentDate().toJulianDay();
+    qlonglong last_update = _settings.value("update", 0).toLongLong();
+    switch (_interval)
+    {
+    case DAILY:
+        if(current_time - last_update >= 1)
+        {
+            updateNow();
+        }
+        break;
+    case WEEKLY:
+        if(current_time - last_update >= 7)
+        {
+            updateNow();
+        }
+        break;
+    case MONTHLY:
+        if(current_time - last_update >= 30)
+        {
+            updateNow();
+        }
+        break;
+    case NEVER:
+        return;
+        break;
+    default:
+        break;
+    }
+}
+
+void CurrencyCache::updateNow()
+{
+    qDebug() << "Sending request for xml";
+
+    QNetworkRequest request(URL);
+    _manager.get(request);
+}
+
+CurrencyCache::UpdateInterval CurrencyCache::interval()
+{
+    return _interval;
+}
+
+void CurrencyCache::setInterval(CurrencyCache::UpdateInterval interval)
+{
+    _interval = interval;
+    _settings.setValue("interval", interval);
+}
+
+void CurrencyCache::getReply(QNetworkReply *reply)
+{
+    if(reply->error() != QNetworkReply::NoError)
+    {
+        qWarning() << "Error while downloading xml:" << reply->errorString();
+        return;
+    }
+
+    qDebug() << "Updating xml";
+
+    setXML(reply->readAll());
+    reply->deleteLater();
+    _settings.setValue("update", QDate::currentDate().toJulianDay());
+}

--- a/src/currencycache.cpp
+++ b/src/currencycache.cpp
@@ -89,6 +89,7 @@ void CurrencyCache::setInterval(CurrencyCache::UpdateInterval interval)
 {
     _interval = interval;
     _settings.setValue("interval", interval);
+    checkUpdate();;
 }
 
 void CurrencyCache::getReply(QNetworkReply *reply)

--- a/src/currencycache.cpp
+++ b/src/currencycache.cpp
@@ -61,10 +61,13 @@ void CurrencyCache::checkUpdate()
             updateNow();
         }
         break;
+    case ALWAYS:
+        updateNow();
+        break;
     case NEVER:
-        return;
         break;
     default:
+        qDebug() << "Unknown update rate" << _interval;
         break;
     }
 }

--- a/src/currencycache.h
+++ b/src/currencycache.h
@@ -22,7 +22,8 @@ public:
         DAILY = 0,
         WEEKLY = 1,
         MONTHLY = 2,
-        NEVER = 3
+        ALWAYS = 3,
+        NEVER = 4
     };
 
     Q_INVOKABLE QString XML();

--- a/src/currencycache.h
+++ b/src/currencycache.h
@@ -1,0 +1,50 @@
+#ifndef CURRENCYCACHE_H
+#define CURRENCYCACHE_H
+
+#include <QObject>
+#include <QString>
+#include <QSettings>
+#include <QNetworkAccessManager>
+#include <QNetworkRequest>
+#include <QNetworkReply>
+#include <QUrl>
+
+class CurrencyCache : public QObject
+{
+    Q_OBJECT
+    Q_ENUMS(UpdateInterval)
+
+    Q_PROPERTY(QString xml READ XML WRITE setXML NOTIFY xmlChanged)
+public:
+    explicit CurrencyCache(QObject *parent = 0);
+
+    enum UpdateInterval {
+        DAILY = 0,
+        WEEKLY = 1,
+        MONTHLY = 2,
+        NEVER = 3
+    };
+
+    Q_INVOKABLE QString XML();
+    Q_INVOKABLE void setXML(QString xml);
+    Q_INVOKABLE void checkUpdate();
+    Q_INVOKABLE void updateNow();
+    Q_INVOKABLE UpdateInterval interval();
+    Q_INVOKABLE void setInterval(UpdateInterval interval);
+
+signals:
+    void xmlChanged(QString xml);
+
+private slots:
+    void getReply(QNetworkReply *reply);
+
+private:
+    static const QUrl URL;
+
+    QString _xml;
+    UpdateInterval _interval;
+    QSettings _settings;
+    QNetworkAccessManager _manager;
+};
+
+#endif // CURRENCYCACHE_H

--- a/src/harbour-unitconverter.cpp
+++ b/src/harbour-unitconverter.cpp
@@ -41,20 +41,26 @@
 #include "converter.h"
 #include "custommodel.h"
 #include "logic.h"
+#include "currencycache.h"
 
 int main(int argc, char *argv[])
 {
     QScopedPointer<QGuiApplication> app(SailfishApp::application(argc, argv));
 
+    QCoreApplication::setOrganizationName("harbour-unitconverter");
+    QCoreApplication::setApplicationName("harbour-unitconverter");
+
     Converter converter;
     CustomModel custom_model;
     Logic logic;
+    CurrencyCache currency_cache;
 
     QScopedPointer<QQuickView> view(SailfishApp::createView());
 
     view->rootContext()->setContextProperty("converter", &converter);
     view->rootContext()->setContextProperty("proxymodel", &custom_model);
     view->rootContext()->setContextProperty("logic", &logic);
+    view->rootContext()->setContextProperty("currencycache", &currency_cache);
 
     view->setSource(SailfishApp::pathTo("qml/harbour-unitconverter.qml"));
 


### PR DESCRIPTION
The currency conversion XML is now cached to the disk and updated on regular intervals (daily,weekly, monthly, always, never; default: daily). This has multiple advantages:
- Privacy: you do not need to tell a (third-party) server whenever you
  open the application
- Reducing internet usage (e.g. if you only have a limited amount of
  high-speed internet)
- Offline usage: You can use the conversion offline (e.g. plane, abroad
  without roaming)

The check for update is performed at the start of the application. Is it also possible to force an update in the options.
